### PR TITLE
Feature/fix enumeration legends

### DIFF
--- a/ogc/__init__.py
+++ b/ogc/__init__.py
@@ -81,7 +81,7 @@ class Layer(tl.HasTraits):
     )
     all_times_valid = tl.Bool(default_value=False)
 
-    legend_graphic_width_inches = tl.Float(default_value=1.5)  # inches
+    legend_graphic_width_inches = tl.Float(default_value=0.7)  # inches
     legend_graphic_height_inches = tl.Float(default_value=2.5)  # inches
     legend_graphic_dpi = tl.Float(default_value=100)
 

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -397,7 +397,7 @@ class LegendGraphic(tl.HasTraits):
         """
         norm = mpl.colors.Normalize(vmin=self.clim[0], vmax=self.clim[1])
         cb = mpl.colorbar.ColorbarBase(ax, cmap=self.cmap, norm=norm)
-        tick_labels = [str(t) for t in cb.ax.get_yticks()]  # Convert ticks to strings
+        tick_labels = [str(t) for t in cb.ax.get_yticks().astype('f4')]  # Convert ticks to strings
         max_label_width = self.get_max_text_width(tick_labels, self.colorbar_fontsize)
         fig_width = max_label_width + 0.4
         fig.set_size_inches(fig_width, self.height,forward=True)
@@ -421,7 +421,6 @@ class LegendGraphic(tl.HasTraits):
         text_widths = []
         for label in labels:
             text = ax.text(0, 0, label, fontsize=font_size)  # Attach text to the figure
-            print(text)
             text_widths.append(text.get_window_extent(renderer).width)
         
         plt.close(fig)  # Close temporary figure

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -181,7 +181,8 @@ class Layer(ogc.Layer):
 
 
 class LegendGraphic(tl.HasTraits):
-    width = tl.Float(default_value=1.5)  # inches
+    width = tl.Float(default_value=0.7)  # inches
+    max_width = tl.Float(default_value=1.5)  # inches
     height = tl.Float(default_value=2.5)  # inches
     dpi = tl.Float(default_value=100)  # pixels per inch
     units = tl.Unicode(default_value=tl.Undefined, allow_none=True)
@@ -235,7 +236,7 @@ class LegendGraphic(tl.HasTraits):
             added_lines = wrapped_units.count("\n")
             added_height = additional_height_for_wrapped_text(self, added_lines, units_fontsize)
             fig_height = min(6.5, added_height + self.height) # add extra height to figure ensure it is less than 6.5 in
-            fig.set_size_inches(self.width, fig_height, forward=True)
+            fig.set_size_inches(self.max_width, fig_height, forward=True)
 
             # Standard height ratio (before adjustments)
             base_figure_height = 2.5  # Original figure height in inches
@@ -257,7 +258,7 @@ class LegendGraphic(tl.HasTraits):
 
         else:
             # no extra space
-            ax = fig.add_axes([0.05, 0.0125, 0.1, 0.975])
+            ax = fig.add_axes([0.1, 0.05, 0.3, 0.9])
 
         if self.enumeration_colors:
             enum_values = list(self.enumeration_colors.keys())

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -210,13 +210,15 @@ class LegendGraphic(tl.HasTraits):
 
         if self.enumeration_colors:
             enum_values = sorted(list(self.enumeration_colors.keys()))
-            bounds = np.array(enum_values + [enum_values[-1] + 1]) - 0.5
+            enum_colors = list(self.enumeration_colors.values())
+            self.cmap = mpl.colors.ListedColormap(enum_colors) #create categorical colomap to replace previous cmap
+            bounds = np.array([val-0.5 for val in np.arange(1,len(enum_values)+1)])
             norm = mpl.colors.BoundaryNorm(bounds, self.cmap.N)
             cb = mpl.colorbar.ColorbarBase(
                 ax,
                 cmap=self.cmap,
                 norm=norm,
-                ticks=list(self.enumeration_colors.keys()),
+                ticks=np.arange(1,len(self.enumeration_legend)+1),
             )
             if self.enumeration_legend:
                 cb.ax.set_yticklabels(list(self.enumeration_legend.values()))

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -255,6 +255,8 @@ class LegendGraphic(tl.HasTraits):
             max_label_width = self.get_max_text_width([wrapped_units], units_fontsize) # Estimates the max label width assuming fontsize 10
             fig_width = max(0.8, max_label_width + 0.2) #define minimum width need or max_label width + some extra margin
             fig.set_size_inches(fig_width, self.height, forward=True)
+        elif self.enumeration_colors:
+            ax = fig.add_axes([0.05, 0.0125, 0.1, 0.975])
         else:
             # no extra space
             ax = fig.add_axes([0.1, 0.05, 0.25, 0.9])

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -332,7 +332,9 @@ class LegendGraphic(tl.HasTraits):
         # add color bar and see if fig width needs to be bigger for tick marks
         norm = mpl.colors.Normalize(vmin=self.clim[0], vmax=self.clim[1])
         cb = mpl.colorbar.ColorbarBase(ax, cmap=self.cmap, norm=norm)
-        tick_labels = [str(t) for t in cb.ax.get_yticks()]  # Convert ticks to strings
+        
+        # Convert ticks to float32 to avoid errors converting float64 to string
+        tick_labels = [str(t) for t in cb.ax.get_yticks().astype('f4')] 
         max_label_width_ticks = self.get_max_text_width(tick_labels, self.colorbar_fontsize)
 
         #define minimum width need or max_label width + some extra margin
@@ -419,6 +421,7 @@ class LegendGraphic(tl.HasTraits):
         text_widths = []
         for label in labels:
             text = ax.text(0, 0, label, fontsize=font_size)  # Attach text to the figure
+            print(text)
             text_widths.append(text.get_window_extent(renderer).width)
         
         plt.close(fig)  # Close temporary figure

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -239,26 +239,25 @@ class LegendGraphic(tl.HasTraits):
             fig.set_size_inches(self.max_width, fig_height, forward=True)
 
             # Standard height ratio (before adjustments)
-            base_figure_height = 2.5  # Original figure height in inches
+            base_figure_height = self.height  # Original figure height in inches
             base_ax_height_ratio = 0.75  # Initial height of ax as a fraction of fig height
             # Compute the new height ratio based on the updated figure height
             adjusted_ax_height_ratio = base_ax_height_ratio * (base_figure_height / fig_height)
             # make axes smaller to fix units
-            ax = fig.add_axes([0.25, 0.05, 0.15, adjusted_ax_height_ratio])
+            ax = fig.add_axes([0.35, 0.05, 0.15, adjusted_ax_height_ratio])
             # adjust fig size to fit units            
 
         elif self.units:
             # adjust figure width based on unit length
             # add space for units
-            ax = fig.add_axes([0.25, 0.05, 0.15, 0.80])
+            ax = fig.add_axes([0.3, 0.05, 0.15, 0.80])
             # adjust fig size to fit units
             max_label_width = self.get_max_text_width([wrapped_units], units_fontsize) # Estimates the max label width assuming fontsize 10
             fig_width = max(0.8, max_label_width + 0.2) #define minimum width need or max_label width + some extra margin
             fig.set_size_inches(fig_width, self.height, forward=True)
-
         else:
             # no extra space
-            ax = fig.add_axes([0.1, 0.05, 0.3, 0.9])
+            ax = fig.add_axes([0.1, 0.05, 0.25, 0.9])
 
         if self.enumeration_colors:
             enum_values = list(self.enumeration_colors.keys())
@@ -288,10 +287,20 @@ class LegendGraphic(tl.HasTraits):
             )
             if self.enumeration_legend:
                 cb.ax.set_yticklabels(enum_labels, fontsize=font_size)
-
-        else:
+        elif self.units:
+            # already adjusted figure size
             norm = mpl.colors.Normalize(vmin=self.clim[0], vmax=self.clim[1])
             cb = mpl.colorbar.ColorbarBase(ax, cmap=self.cmap, norm=norm)
+        else:
+            # adjust figure width based on tick labels
+            norm = mpl.colors.Normalize(vmin=self.clim[0], vmax=self.clim[1])
+            cb = mpl.colorbar.ColorbarBase(ax, cmap=self.cmap, norm=norm)
+            tick_labels = [str(t) for t in cb.ax.get_yticks()]  # Convert ticks to strings
+            font_size = 10
+            max_label_width = self.get_max_text_width(tick_labels, font_size)
+            fig_width = max_label_width + 0.4
+            fig.set_size_inches(fig_width, self.height,forward=True)
+
 
 
 

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -236,9 +236,6 @@ class LegendGraphic(tl.HasTraits):
             mpl.colorbar.ColorbarBase(ax, cmap=self.cmap, norm=norm)
         elif self.units:
             fig, ax = self.adjust_fig_width_for_unwrapped_units(fig, units_str)
-            # add color bars
-            norm = mpl.colors.Normalize(vmin=self.clim[0], vmax=self.clim[1])
-            mpl.colorbar.ColorbarBase(ax, cmap=self.cmap, norm=norm)
         elif self.enumeration_colors:
             # set axis for enumeration
             ax = fig.add_axes([0.05, 0.0125, 0.1, 0.975])
@@ -312,7 +309,7 @@ class LegendGraphic(tl.HasTraits):
         # Compute the new height ratio based on the updated figure height
         adjusted_ax_height_ratio = base_ax_height_ratio * (base_figure_height / fig_height)
         # make axes smaller to fix units
-        ax = fig.add_axes([0.35, 0.05, 0.15, adjusted_ax_height_ratio])
+        ax = fig.add_axes([0.25, 0.05, 0.15, adjusted_ax_height_ratio])
         return fig, ax
 
     def adjust_fig_width_for_unwrapped_units(self, fig, units_str):
@@ -328,12 +325,20 @@ class LegendGraphic(tl.HasTraits):
             tuple: Updated figure and adjusted axis.
         """
         # add space for units
-        ax = fig.add_axes([0.3, 0.05, 0.15, 0.80])
+        ax = fig.add_axes([0.25, 0.05, 0.15, 0.80])
         # Estimates the max label width assuming fontsize 10
-        max_label_width = self.get_max_text_width([units_str], self.units_fontsize) 
+        max_label_width_units = self.get_max_text_width([units_str], self.units_fontsize) 
+        
+        # add color bar and see if fig width needs to be bigger for tick marks
+        norm = mpl.colors.Normalize(vmin=self.clim[0], vmax=self.clim[1])
+        cb = mpl.colorbar.ColorbarBase(ax, cmap=self.cmap, norm=norm)
+        tick_labels = [str(t) for t in cb.ax.get_yticks()]  # Convert ticks to strings
+        max_label_width_ticks = self.get_max_text_width(tick_labels, self.colorbar_fontsize)
+
         #define minimum width need or max_label width + some extra margin
-        fig_width = max(self.min_width, max_label_width + 0.2) 
+        fig_width = max(self.min_width, max_label_width_units+0.2, max_label_width_ticks+0.4) 
         fig.set_size_inches(fig_width, self.height, forward=True)
+
         return fig, ax
         
     def create_enumeration_legend(self, fig, ax):

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -15,6 +15,7 @@ import numpy as np
 import xarray as xr
 import json
 import textwrap
+import re
 
 
 
@@ -207,16 +208,16 @@ class LegendGraphic(tl.HasTraits):
         )
         # check if there are units and see if they are long and need to be wrapped
         if self.units:
-            # format characters
             units = "[%s]" % self.units
-            units = units.replace("^2", "$^2\!$")
-            units = units.replace("^-6", "$^{-6}\!$")
-
             units_fontsize = 13 #defualt unit fontsize
             max_width_chars = 16 #maximum characters allowed in first line
+ 
             needs_wrap = len(units) > max_width_chars  # if characters are greater than 16 then wrap text and shrink colorbar
             # currently only allows for 2 lines
             wrapped_units = self.wrap_text(units, max_width_chars)
+            # format exponents
+            units = re.sub(r"\^(\d+)", r"$^{\1}\!$", units)            
+            units = re.sub(r"\^-(\d+)", r"$^{-\1}\!$", units)
             # add units to figure
             fig.text(
                 0.5,

--- a/ogc/podpac.py
+++ b/ogc/podpac.py
@@ -220,7 +220,7 @@ class LegendGraphic(tl.HasTraits):
             fig.set_size_inches(fig_width,fig_height,forward=True)
             
             self.cmap = mpl.colors.ListedColormap(enum_colors) #create categorical colomap to replace previous cmap
-            bounds = np.array([val-0.5 for val in np.arange(1,len(enum_values)+1)])
+            bounds = np.array([val-0.5 for val in np.arange(1,len(enum_values)+2)])
             norm = mpl.colors.BoundaryNorm(bounds, self.cmap.N)
             cb = mpl.colorbar.ColorbarBase(
                 ax,
@@ -249,7 +249,7 @@ class LegendGraphic(tl.HasTraits):
             )
 
         output = io.BytesIO()
-        fig.savefig(output, format=self.img_format)
+        fig.savefig('/opt/geowatch/local_data/test.png', format=self.img_format)
         pyplot.close("all")
         output.seek(0)
         return output


### PR DESCRIPTION
These changes adjust the LegendGraphic class. They primarily add dynamic sizing for the legend height and width based on the content of the legend. The main cases are legends with units that need text wrapping for the units, legends with units unwrapped, legends that use categorical tick labels (enumerations), and legends that are made of a color bar and number tick marks.