### PR TITLE
Add support for hierarchical layers in WMS GetCapabilities

### DIFF
--- a/ogc/__init__.py
+++ b/ogc/__init__.py
@@ -68,10 +68,11 @@ class Layer(tl.HasTraits):
           see podpac.Layer for example of a concrete class.
     """
 
+    safe_group_default = "Default"
     identifier = tl.Unicode()
     title = tl.Unicode(default_value="An OGC Layer")
     abstract = tl.Unicode(default_value="This is an example OGC Layer")
-    group = tl.Unicode(default_value="Default")
+    group = tl.Unicode(default_value=safe_group_default)
     group_path = tl.List(trait=tl.Unicode(default_value=None, allow_none=True))
     is_fouo = tl.Bool(default_value=False)
     grid_coordinates = tl.Instance(klass=GridCoordinates, default_value=GridCoordinates())
@@ -88,7 +89,10 @@ class Layer(tl.HasTraits):
 
     @tl.validate("group")
     def _validate_group(self, proposal: dict) -> str:
-        """Validate the group value to ensure it is URL safe.
+        """Validate the group value to ensure it is URL safe, with a default fallback.
+
+        Allow only charcters from the following list (A-Z, a-z, 0-9, -, _, .)
+        Enforce a maximum length of 255 characters.
 
         Parameters
         ----------
@@ -98,12 +102,16 @@ class Layer(tl.HasTraits):
         Returns
         -------
         str
-            The sanitized group string.
+            The sanitized group string or safe default value.
         """
         validated_group = re.sub(r"[^-A-Za-z0-9_]", "-", proposal["value"])
         validated_group = re.sub(r"-+", "-", validated_group)
         validated_group = validated_group.strip("-")
-        return validated_group
+
+        if len(validated_group) > 0 and len(validated_group) < 255:
+            return validated_group
+
+        return self.safe_group_default
 
     @property
     def legend_graphic_width(self):

--- a/ogc/__init__.py
+++ b/ogc/__init__.py
@@ -91,8 +91,8 @@ class Layer(tl.HasTraits):
     def _validate_group(self, proposal: dict) -> str:
         """Validate the group value to ensure it is URL safe, with a default fallback.
 
-        Allow only charcters from the following list (A-Z, a-z, 0-9, -, _, .)
-        Enforce a maximum length of 255 characters.
+        Allow only charcters from the following list (A-Z, a-z, 0-9, -, _)
+        Enforce a maximum length of 254 characters.
 
         Parameters
         ----------

--- a/ogc/__init__.py
+++ b/ogc/__init__.py
@@ -2,6 +2,7 @@
 OGC WMS/WCS (v1.3.0/v1.0.0) server
 """
 
+import re
 import traitlets as tl
 import datetime
 
@@ -71,6 +72,7 @@ class Layer(tl.HasTraits):
     title = tl.Unicode(default_value="An OGC Layer")
     abstract = tl.Unicode(default_value="This is an example OGC Layer")
     group = tl.Unicode(default_value="Default")
+    group_path = tl.List(trait=tl.Unicode(default_value=None, allow_none=True))
     is_fouo = tl.Bool(default_value=False)
     grid_coordinates = tl.Instance(klass=GridCoordinates, default_value=GridCoordinates())
     valid_times = tl.List(
@@ -83,6 +85,25 @@ class Layer(tl.HasTraits):
     legend_graphic_width_inches = tl.Float(default_value=0.7)  # inches
     legend_graphic_height_inches = tl.Float(default_value=2.5)  # inches
     legend_graphic_dpi = tl.Float(default_value=100)
+
+    @tl.validate("group")
+    def _validate_group(self, proposal: dict) -> str:
+        """Validate the group value to ensure it is URL safe.
+
+        Parameters
+        ----------
+        proposal: dict
+            The traitlet proposal for group.
+
+        Returns
+        -------
+        str
+            The sanitized group string.
+        """
+        validated_group = re.sub(r"[^-A-Za-z0-9_]", "-", proposal["value"])
+        validated_group = re.sub(r"-+", "-", validated_group)
+        validated_group = validated_group.strip("-")
+        return validated_group
 
     @property
     def legend_graphic_width(self):

--- a/ogc/test/test_core.py
+++ b/ogc/test/test_core.py
@@ -39,8 +39,9 @@ layer2 = pogc.Layer(
         ("Group", "Group"),
         ("-Group: 1-", "Group-1"),
         ("🌍", "Default"),
-        ("æ", "Default"),
-        ("a" * 255, "Default"),
+        ("æ", "Default"),  # high ascii character
+        ("\x00", "Default"),  # null character
+        ("a" * 255, "Default"),  # oversized string
     ],
 )
 def test_ogc_layer_group_validation(unsanitized: str, sanitized: str):

--- a/ogc/test/test_core.py
+++ b/ogc/test/test_core.py
@@ -33,21 +33,35 @@ layer2 = pogc.Layer(
 )
 
 
-def test_ogc_layer_group_validation():
+@pytest.mark.parametrize(
+    "unsanitized, sanitized",
+    [
+        ("Group", "Group"),
+        ("-Group: 1-", "Group-1"),
+        ("🌍", "Default"),
+        ("æ", "Default"),
+        ("a" * 255, "Default"),
+    ],
+)
+def test_ogc_layer_group_validation(unsanitized: str, sanitized: str):
+    """Test the group name for layer creation is sanitized to a URL safe string.
+
+    Parameters
+    ----------
+    unsanitized : str
+        The unsanitized group.
+    sanitized : str
+        The expected sanitized output following validation.
     """
-    Test the group name for layer creation is sanitized to a URL safe string.
-    """
-    unsanitized_group = "-Group: 1-"
-    sanitized_group = "Group-1"
     layer = pogc.Layer(
         node=node1,
         identifier="layer",
         title="Layer",
         abstract="Layer Data",
-        group=unsanitized_group,
+        group=unsanitized,
     )
 
-    assert layer.group == sanitized_group
+    assert layer.group == sanitized
 
 
 def test_ogc_core_get_coverage_from_id():

--- a/ogc/test/test_core.py
+++ b/ogc/test/test_core.py
@@ -4,6 +4,7 @@ from ogc import podpac as pogc
 import podpac
 import pytest
 import numpy as np
+import lxml.etree
 from ogc.wcs_response_1_0_0 import Coverage
 
 # Create some podpac nodes
@@ -30,6 +31,23 @@ layer2 = pogc.Layer(
     abstract="Layer2 Data",
     group="Layers",
 )
+
+
+def test_ogc_layer_group_validation():
+    """
+    Test the group name for layer creation is sanitized to a URL safe string.
+    """
+    unsanitized_group = "-Group: 1-"
+    sanitized_group = "Group-1"
+    layer = pogc.Layer(
+        node=node1,
+        identifier="layer",
+        title="Layer",
+        abstract="Layer Data",
+        group=unsanitized_group,
+    )
+
+    assert layer.group == sanitized_group
 
 
 def test_ogc_core_get_coverage_from_id():
@@ -156,6 +174,54 @@ def test_ogc_core_handle_wms_kv_get_capabilities():
     response = ogc.handle_wms_kv(args)
     assert isinstance(response, str)
     assert "WMS_Capabilities" in response
+
+
+def test_ogc_core_handle_wms_kv_get_capabilities_hierachical_layers():
+    """
+    Test the handle_wms_kv method of the OGC class with hierarchical layers.
+    Ensure a valid GetCapabilities request returns nested layers.
+    """
+    layer_root = pogc.Layer(
+        node=node1,
+        identifier="layerRoot",
+        title="Layer Root",
+        abstract="Layer Root Data",
+    )
+    layer_nested = pogc.Layer(
+        node=node1,
+        identifier="layerNested",
+        title="Layer Nested",
+        abstract="Layer Nested Data",
+        group_path=["Parent", "Child"],
+    )
+
+    ogc = core.OGC(layers=[layer_root, layer_nested])
+    args = {
+        "request": "GetCapabilities",
+        "service": "WMS",
+        "version": "1.3.0",
+        "base_url": None,
+    }
+    response = ogc.handle_wms_kv(args)
+    assert isinstance(response, str)
+    assert "WMS_Capabilities" in response
+
+    capability = "*[local-name()='Capability']"
+    layer = "*[local-name()='Layer']"
+    title = "*[local-name()='Title']"
+    root = lxml.etree.fromstring(response.encode("utf-8"))
+
+    layers = root.xpath(f".//{capability}/{layer}/{title}/text()")
+    assert {ogc.service_group_title} == set(layers)
+
+    layers = root.xpath(f".//{capability}/{layer}/{layer}/{title}/text()")
+    assert {layer_root.title, layer_nested.group_path[0]} == set(layers)
+
+    layers = root.xpath(f".//{capability}/{layer}/{layer}/{layer}/{title}/text()")
+    assert {layer_nested.group_path[1]} == set(layers)
+
+    layers = root.xpath(f".//{capability}/{layer}/{layer}/{layer}/{layer}/{title}/text()")
+    assert {layer_nested.title} == set(layers)
 
 
 def test_ogc_core_handle_wms_kv_get_capabilities_invalid_service():

--- a/ogc/wms_response_1_3_0.py
+++ b/ogc/wms_response_1_3_0.py
@@ -11,6 +11,7 @@ from ogc import settings
 logger = logging.getLogger(__name__)
 
 SERVICE_VERSION = "1.3.0"
+INDENT = "    "  # Constant for a single indentation constant
 
 from ogc.wcs_response_1_0_0 import Coverage
 
@@ -123,16 +124,15 @@ class Capabilities(ogc_common.XMLNode):
         return display_times
 
     def coverage_layer(self, coverage, depth):
-        indent = "    "
-        xml = indent * depth + """<Layer queryable="0" opaque="0" cascaded="1">\n"""
+        xml = INDENT * depth + """<Layer queryable="0" opaque="0" cascaded="1">\n"""
         if coverage.identifier:
-            xml += indent * (depth + 1) + f"<Name>{escape(coverage.identifier)}</Name>\n"
+            xml += INDENT * (depth + 1) + f"<Name>{escape(coverage.identifier)}</Name>\n"
         if coverage.title:
-            xml += indent * (depth + 1) + f"<Title>{escape(coverage.title)}</Title>\n"
+            xml += INDENT * (depth + 1) + f"<Title>{escape(coverage.title)}</Title>\n"
         else:
             logger.info("Invalid layer. Missing title.")
         if coverage.abstract:
-            xml += indent * (depth + 1) + f"<Abstract>{escape(coverage.abstract)}</Abstract>\n"
+            xml += INDENT * (depth + 1) + f"<Abstract>{escape(coverage.abstract)}</Abstract>\n"
 
         xml += self._get_CRS_and_BoundingBox(depth + 1)
 
@@ -144,7 +144,7 @@ class Capabilities(ogc_common.XMLNode):
             min_time = coverage.layer.valid_times[0]
             max_time = coverage.layer.valid_times[-1]
             time_dimension_str = (
-                indent * (depth + 1)
+                INDENT * (depth + 1)
                 + """<Dimension name="TIME" units="ISO8601" default="{default_time}">{times}</Dimension>\n"""
             )
 
@@ -189,17 +189,17 @@ class Capabilities(ogc_common.XMLNode):
         )
 
         # Write the style section
-        xml += indent * (depth + 1) + """<Style>\n"""
-        xml += indent * (depth + 2) + """<Name>{}</Name>\n""".format(coverage.identifier)
-        xml += indent * (depth + 2) + """<Title>{}</Title>\n""".format(coverage.title)
-        xml += indent * (depth + 2) + """<LegendURL width="{width}" height="{height}">\n""".format(
+        xml += INDENT * (depth + 1) + """<Style>\n"""
+        xml += INDENT * (depth + 2) + """<Name>{}</Name>\n""".format(coverage.identifier)
+        xml += INDENT * (depth + 2) + """<Title>{}</Title>\n""".format(coverage.title)
+        xml += INDENT * (depth + 2) + """<LegendURL width="{width}" height="{height}">\n""".format(
             height=legend_graphic_height, width=legend_graphic_width
         )
-        xml += indent * (depth + 3) + """<Format>image/png</Format>\n"""
-        xml += indent * (depth + 3) + """<OnlineResource xlink:type="simple" xlink:href="{}"/>\n""".format(legend_link)
-        xml += indent * (depth + 2) + """</LegendURL>\n"""
-        xml += indent * (depth + 1) + """</Style>\n"""
-        xml += indent * depth + """</Layer>\n"""
+        xml += INDENT * (depth + 3) + """<Format>image/png</Format>\n"""
+        xml += INDENT * (depth + 3) + """<OnlineResource xlink:type="simple" xlink:href="{}"/>\n""".format(legend_link)
+        xml += INDENT * (depth + 2) + """</LegendURL>\n"""
+        xml += INDENT * (depth + 1) + """</Style>\n"""
+        xml += INDENT * depth + """</Layer>\n"""
 
         return xml
 
@@ -220,9 +220,8 @@ class Capabilities(ogc_common.XMLNode):
         str
             The XML layer output for the tree.
         """
-        indent = "    "
-        xml = indent * depth + "<Layer>\n"
-        xml += indent * (depth + 1) + "<Title>{}</Title>\n".format(escape(title) if title else "")
+        xml = INDENT * depth + "<Layer>\n"
+        xml += INDENT * (depth + 1) + "<Title>{}</Title>\n".format(escape(title) if title else "")
         xml += self._get_CRS_and_BoundingBox(depth + 1)
 
         for child_title, child_item in tree["children"].items():
@@ -231,7 +230,7 @@ class Capabilities(ogc_common.XMLNode):
         for coverage in tree["coverages"]:
             xml += self.coverage_layer(coverage, depth + 1)
 
-        xml += indent * depth + "</Layer>\n"
+        xml += INDENT * depth + "</Layer>\n"
         return xml
 
     def layers(self):
@@ -286,12 +285,10 @@ version="{capabilities.version}">
             return "{}".format(input_number)
 
     def _get_CRS_and_BoundingBox(self, depth=3):
-        indent = "    "
-
         output_text = (
             "\n".join(
                 [
-                    indent * depth + """<CRS>{epsg}</CRS>""".format(epsg=epsg.upper())
+                    INDENT * depth + """<CRS>{epsg}</CRS>""".format(epsg=epsg.upper())
                     for epsg, bbox in list(settings.WMS_CRS.items())
                 ]
             )
@@ -300,17 +297,17 @@ version="{capabilities.version}">
 
         output_text += "\n".join(
             [
-                indent * depth + "<EX_GeographicBoundingBox>",
-                indent * (depth + 1) + "<westBoundLongitude>-180</westBoundLongitude>",
-                indent * (depth + 1) + "<eastBoundLongitude>180</eastBoundLongitude>",
-                indent * (depth + 1) + "<southBoundLatitude>-90</southBoundLatitude>",
-                indent * (depth + 1) + "<northBoundLatitude>90</northBoundLatitude>",
-                indent * (depth) + "</EX_GeographicBoundingBox>",
+                INDENT * depth + "<EX_GeographicBoundingBox>",
+                INDENT * (depth + 1) + "<westBoundLongitude>-180</westBoundLongitude>",
+                INDENT * (depth + 1) + "<eastBoundLongitude>180</eastBoundLongitude>",
+                INDENT * (depth + 1) + "<southBoundLatitude>-90</southBoundLatitude>",
+                INDENT * (depth + 1) + "<northBoundLatitude>90</northBoundLatitude>",
+                INDENT * (depth) + "</EX_GeographicBoundingBox>",
             ]
         )
         output_text += "\n".join(
             [
-                indent * depth
+                INDENT * depth
                 + """<BoundingBox CRS="{epsg}"  minx="{minx}" miny="{miny}" maxx="{maxx}" maxy="{maxy}"/>""".format(
                     epsg=epsg.upper(),
                     minx=Capabilities._format_number(bbox["minx"]),

--- a/ogc/wms_response_1_3_0.py
+++ b/ogc/wms_response_1_3_0.py
@@ -11,7 +11,7 @@ from ogc import settings
 logger = logging.getLogger(__name__)
 
 SERVICE_VERSION = "1.3.0"
-INDENT = "    "  # Constant for a single indentation constant
+INDENT = "    "  # Constant for a single XML indentation
 
 from ogc.wcs_response_1_0_0 import Coverage
 

--- a/ogc/wms_response_1_3_0.py
+++ b/ogc/wms_response_1_3_0.py
@@ -123,7 +123,21 @@ class Capabilities(ogc_common.XMLNode):
 
         return display_times
 
-    def coverage_layer(self, coverage, depth):
+    def coverage_layer(self, coverage: Coverage, depth: int) -> str:
+        """Create the XML string output for a coverage layer.
+
+        Parameters
+        ----------
+        coverage : Coverage
+            The coverage layer to create XML for.
+        depth : int
+            The depth for indentation.
+
+        Returns
+        -------
+        str
+            The XML string output for the coverage layer.
+        """
         xml = INDENT * depth + """<Layer queryable="0" opaque="0" cascaded="1">\n"""
         if coverage.identifier:
             xml += INDENT * (depth + 1) + f"<Name>{escape(coverage.identifier)}</Name>\n"

--- a/ogc/wms_response_1_3_0.py
+++ b/ogc/wms_response_1_3_0.py
@@ -3,6 +3,7 @@ from xml.sax.saxutils import escape
 
 import traitlets as tl
 import numpy as np
+from collections import defaultdict
 
 from ogc import ogc_common
 from ogc import settings
@@ -121,18 +122,19 @@ class Capabilities(ogc_common.XMLNode):
 
         return display_times
 
-    def coverage_layer(self, coverage):
-        xml = """       <Layer queryable="0" opaque="0" cascaded="1">\n"""
+    def coverage_layer(self, coverage, depth):
+        indent = "    "
+        xml = indent * depth + """<Layer queryable="0" opaque="0" cascaded="1">\n"""
         if coverage.identifier:
-            xml += f"            <Name>{escape(coverage.identifier)}</Name>\n"
+            xml += indent * (depth + 1) + f"<Name>{escape(coverage.identifier)}</Name>\n"
         if coverage.title:
-            xml += f"            <Title>{escape(coverage.title)}</Title>\n"
+            xml += indent * (depth + 1) + f"<Title>{escape(coverage.title)}</Title>\n"
         else:
             logger.info("Invalid layer. Missing title.")
         if coverage.abstract:
-            xml += f"            <Abstract>{escape(coverage.abstract)}</Abstract>\n"
+            xml += indent * (depth + 1) + f"<Abstract>{escape(coverage.abstract)}</Abstract>\n"
 
-        xml += self._get_CRS_and_BoundingBox()
+        xml += self._get_CRS_and_BoundingBox(depth + 1)
 
         if (
             hasattr(coverage.layer, "valid_times")
@@ -142,7 +144,8 @@ class Capabilities(ogc_common.XMLNode):
             min_time = coverage.layer.valid_times[0]
             max_time = coverage.layer.valid_times[-1]
             time_dimension_str = (
-                """            <Dimension name="TIME" units="ISO8601" default="{default_time}">{times}</Dimension>\n"""
+                indent * (depth + 1)
+                + """<Dimension name="TIME" units="ISO8601" default="{default_time}">{times}</Dimension>\n"""
             )
 
             # Find last time with seconds == 0
@@ -186,36 +189,68 @@ class Capabilities(ogc_common.XMLNode):
         )
 
         # Write the style section
-        xml += """            <Style>\n"""
-        xml += """                <Name>{}</Name>\n""".format(coverage.identifier)
-        xml += """                <Title>{}</Title>\n""".format(coverage.title)
-        xml += """                <LegendURL width="{width}" height="{height}">\n""".format(
+        xml += indent * (depth + 1) + """<Style>\n"""
+        xml += indent * (depth + 2) + """<Name>{}</Name>\n""".format(coverage.identifier)
+        xml += indent * (depth + 2) + """<Title>{}</Title>\n""".format(coverage.title)
+        xml += indent * (depth + 2) + """<LegendURL width="{width}" height="{height}">\n""".format(
             height=legend_graphic_height, width=legend_graphic_width
         )
-        xml += """                    <Format>image/png</Format>\n"""
-        xml += """                    <OnlineResource xlink:type="simple" xlink:href="{}"/>\n""".format(legend_link)
-        xml += """                </LegendURL>\n"""
-        xml += """            </Style>\n"""
-        xml += """        </Layer>\n"""
+        xml += indent * (depth + 3) + """<Format>image/png</Format>\n"""
+        xml += indent * (depth + 3) + """<OnlineResource xlink:type="simple" xlink:href="{}"/>\n""".format(legend_link)
+        xml += indent * (depth + 2) + """</LegendURL>\n"""
+        xml += indent * (depth + 1) + """</Style>\n"""
+        xml += indent * depth + """</Layer>\n"""
 
         return xml
 
-    def layers(self):
-        xml = "    <Layer>\n"
-        xml += "        <Title>{}</Title>\n".format(
-            escape(self.service_group_title) if self.service_group_title else ""
-        )
-        xml += self._get_CRS_and_BoundingBox(depth=2)
+    def render_tree(self, tree: dict, title: str | None, depth=1) -> str:
+        """Create the XML string output for the coverage tree.
 
+        Parameters
+        ----------
+        tree : dict
+            The tree to create the layer XML output for.
+        title : str | None
+            The title of the current tree layer.
+        depth : int, optional
+            The depth for indentation, by default 1.
+
+        Returns
+        -------
+        str
+            The XML layer output for the tree.
+        """
+        indent = "    "
+        xml = indent * depth + "<Layer>\n"
+        xml += indent * (depth + 1) + "<Title>{}</Title>\n".format(escape(title) if title else "")
+        xml += self._get_CRS_and_BoundingBox(depth + 1)
+
+        for child_title, child_item in tree["children"].items():
+            xml += self.render_tree(child_item, child_title, depth + 1)
+
+        for coverage in tree["coverages"]:
+            xml += self.coverage_layer(coverage, depth + 1)
+
+        xml += indent * depth + "</Layer>\n"
+        return xml
+
+    def layers(self):
         # If configured, trim layers list to layers specified in settings
         if self.limit_layers:
             self.coverages = [layer for layer in self.coverages if layer.identifier in self.layer_subset]
 
-        for coverage in self.coverages:
-            xml += self.coverage_layer(coverage)
+        coverage_tree = self.coverage_tree_item()
 
-        # end layers list
-        xml += """    </Layer>"""
+        for coverage in self.coverages:
+            group_path = coverage.layer.group_path if coverage.layer.group_path is not None else []
+
+            tree_item = coverage_tree
+            for group in group_path:
+                tree_item = tree_item["children"][group]
+
+            tree_item["coverages"].append(coverage)
+
+        xml = self.render_tree(coverage_tree, self.service_group_title)
 
         return xml
 
@@ -287,3 +322,17 @@ version="{capabilities.version}">
             ]
         )
         return output_text
+
+    @staticmethod
+    def coverage_tree_item() -> dict:
+        """Create an empty coverage tree item for hierarchical coverage structuring.
+
+        Returns
+        -------
+        dict
+            Dictionary containing coverages and sub-items in the tree.
+        """
+        return {
+            "children": defaultdict(Capabilities.coverage_tree_item),
+            "coverages": [],
+        }


### PR DESCRIPTION
Support optional hierarchical layering in WMS GetCapabilities.

- The newly added `group_path` can be used to define GetCapabilities pathing.
- The `group_path` is optional and relative to the main root path.
- Coverage layers cannot currently be nested inside other coverage layers.