### PR TITLE
Convert http to https where possible and labeled with NOSONAR when not

### DIFF
--- a/ogc/edr/edr_api.py
+++ b/ogc/edr/edr_api.py
@@ -494,7 +494,7 @@ class EdrAPI:
                         "label": {"en": value["title"]},
                         "symbol": {
                             "value": value["x-ogc-unit"],
-                            "type": "http://www.opengis.net/def/uom/UCUM/",
+                            "type": "http://www.opengis.net/def/uom/UCUM/",  # NOSONAR(S5332) - This is part of the EDR specification
                         },
                     },
                 }

--- a/ogc/edr/test/test_edr_routes.py
+++ b/ogc/edr/test/test_edr_routes.py
@@ -27,7 +27,7 @@ def mock_request(request_args: Dict[str, Any] | None = None) -> APIRequest:
         Mock API request for route testing.
     """
     request_args = request_args if request_args is not None else {}
-    environ = create_environ(base_url="http://127.0.0.1:5000/ogc/edr")
+    environ = create_environ(base_url="https://127.0.0.1:5000/ogc/edr")
     request = Request(environ)
     request.args = ImmutableMultiDict(request_args.items())
     return APIRequest(request, ["en"])
@@ -387,8 +387,8 @@ def test_edr_routes_collection_query_missing_parameter(
 
 def test_edr_routes_request_url_updates_configuration_url():
     """Test the EDR routes request base URL updates the configuration URL."""
-    request_url = "http://test:5000/ogc/edr/static/img/logo.png"
-    expected_config_url = "http://test:5000/ogc/edr"
+    request_url = "https://test:5000/ogc/edr/static/img/logo.png"
+    expected_config_url = "https://test:5000/ogc/edr"
     request = mock_request({"base_url": request_url})
     edr_routes = EdrRoutes(layers=[])
 

--- a/ogc/settings.py
+++ b/ogc/settings.py
@@ -11,9 +11,15 @@ import os
 # Settings applied around the OGC server package.
 crs_84 = "crs:84"
 epsg_4326 = "epsg:4326"
-crs_84_uri_format = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-crs_84h_uri_format = "http://www.opengis.net/def/crs/OGC/0/CRS84h"
-epsg_4326_uri_format = "http://www.opengis.net/def/crs/EPSG/0/4326"
+crs_84_uri_format = (
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84"  # NOSONAR(S5332) - This is part of the EDR specification
+)
+crs_84h_uri_format = (
+    "http://www.opengis.net/def/crs/OGC/0/CRS84h"  # NOSONAR(S5332) - This is part of the EDR specification
+)
+epsg_4326_uri_format = (
+    "http://www.opengis.net/def/crs/EPSG/0/4326"  # NOSONAR(S5332) - This is part of the EDR specification
+)
 
 # Default/Supported WMS CRS/SRS
 WMS_CRS = {


### PR DESCRIPTION
SonarQube flags `http://` URLs as security hotspots, so we can do away with a number of them with code alterations.