### PR TITLE
Add logic to block path traversal in static files

### DIFF
--- a/ogc/edr/edr_routes.py
+++ b/ogc/edr/edr_routes.py
@@ -108,6 +108,8 @@ class EdrRoutes(tl.HasTraits):
         static_path = os.path.join(os.path.dirname(pygeoapi.__file__), "static")
         if "templates" in self.api.config["server"]:
             static_path = self.api.config["server"]["templates"].get("static", static_path)
+
+        # Use a safe join to ensure the untrusted path is a subpath of the trusted static directory
         safe_path = safe_join(static_path, file_path)
         if safe_path is not None and os.path.isfile(safe_path):
             mime_type, _ = mimetypes.guess_type(safe_path)

--- a/ogc/edr/edr_routes.py
+++ b/ogc/edr/edr_routes.py
@@ -7,6 +7,7 @@ import pygeoapi.l10n
 import pygeoapi.plugin
 import pygeoapi.api
 from typing import Tuple, Any, Dict, Generator
+from werkzeug.security import safe_join
 from http import HTTPStatus
 from copy import deepcopy
 from pygeoapi.openapi import get_oas
@@ -107,11 +108,11 @@ class EdrRoutes(tl.HasTraits):
         static_path = os.path.join(os.path.dirname(pygeoapi.__file__), "static")
         if "templates" in self.api.config["server"]:
             static_path = self.api.config["server"]["templates"].get("static", static_path)
-        file_path = os.path.join(static_path, file_path)
-        if os.path.isfile(file_path):
-            mime_type, _ = mimetypes.guess_type(file_path)
+        safe_path = safe_join(static_path, file_path)
+        if safe_path is not None and os.path.isfile(safe_path):
+            mime_type, _ = mimetypes.guess_type(safe_path)
             mime_type = mime_type or "application/octet-stream"
-            with open(file_path, "rb") as f:
+            with open(safe_path, "rb") as f:
                 content = f.read()
             return {"Content-Type": mime_type}, HTTPStatus.OK, content
         else:

--- a/ogc/edr/test/test_edr_routes.py
+++ b/ogc/edr/test/test_edr_routes.py
@@ -44,6 +44,20 @@ def test_edr_routes_static_files_valid_path():
     assert headers["Content-Type"] == "image/png"
 
 
+def test_edr_routes_static_files_prevents_path_traversal():
+    """Test the EDR static routes prevents path traversal."""
+    request = mock_request()
+    edr_routes = EdrRoutes(layers=[])
+
+    static_path = os.path.join(os.path.dirname(__file__), "..", "static")
+    file_path = os.path.join(os.path.dirname(__file__), "..")
+    with tempfile.NamedTemporaryFile(dir=file_path) as temp_file:
+        relative_path = os.path.relpath(temp_file.name, static_path)
+        _, status, _ = edr_routes.static_files(request, relative_path)
+        assert os.path.exists(temp_file.name)
+        assert status == HTTPStatus.NOT_FOUND
+
+
 def test_edr_routes_static_files_invalid_path():
     """Test the EDR static routes with an invalid static file path."""
     request = mock_request()

--- a/ogc/test/test_servers.py
+++ b/ogc/test/test_servers.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from ogc import servers
 from ogc import core
 from ogc import podpac as pogc
@@ -177,6 +179,26 @@ def test_edr_render_get_collections(enable_edr_in_env, client):
 def test_edr_render_post_returns_405(enable_edr_in_env, client):
     response = client.post("/ogc/edr")
     assert response.status_code == 405
+
+
+def test_edr_render_static_file_returns_200(enable_edr_in_env, client):
+    static_path = os.path.join(os.path.dirname(__file__), "..", "edr", "static")
+    file_path = static_path
+    with tempfile.NamedTemporaryFile(dir=file_path) as temp_file:
+        relative_path = os.path.relpath(temp_file.name, static_path)
+        response = client.get(f"/ogc/edr/static/{relative_path}")
+        assert os.path.exists(temp_file.name)
+        assert response.status_code == 200
+
+
+def test_edr_render_static_file_path_traversal_returns_404(enable_edr_in_env, client):
+    static_path = os.path.join(os.path.dirname(__file__), "..", "edr", "static")
+    file_path = os.path.join(os.path.dirname(__file__), "..", "edr")
+    with tempfile.NamedTemporaryFile(dir=file_path) as temp_file:
+        relative_path = os.path.relpath(temp_file.name, static_path)
+        response = client.get(f"/ogc/edr/static/{relative_path}")
+        assert os.path.exists(temp_file.name)
+        assert response.status_code == 404
 
 
 def test_edr_render_query_string_too_long_returns_400(enable_edr_in_env, client):


### PR DESCRIPTION
Check for path traversals and only allow safe paths.